### PR TITLE
fix: make use long form for eds and fix naming verbage

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@
 
 ### AdobeEDS <a name="AdobeEDS" id="cdk-adobe-eds.AdobeEDS"></a>
 
-Infrastructure for Adobe Edge Delivery Service.
+CDN infrastructure for Adobe Edge Delivery Services.
 
 #### Initializers <a name="Initializers" id="cdk-adobe-eds.AdobeEDS.Initializer"></a>
 
@@ -116,7 +116,7 @@ public readonly edsDistribution: EDSDistribution;
 
 ### EDSDistribution <a name="EDSDistribution" id="cdk-adobe-eds.EDSDistribution"></a>
 
-A high level Construct for creating infrastructure required to support Adobe AEM Edge Delivery Service.
+A high level Construct for creating infrastructure required to support Adobe AEM Edge Delivery Services.
 
 This stands for
 "Edge Delivery Service Content Delivery Construct."
@@ -268,7 +268,7 @@ public readonly distribution: Distribution;
 
 ### AdobeEDSConstructProps <a name="AdobeEDSConstructProps" id="cdk-adobe-eds.AdobeEDSConstructProps"></a>
 
-All configuration options for the Adobe EDS CDN deployment.
+All configuration options for the Adobe Edge Delivery Services CDN deployment.
 
 #### Initializer <a name="Initializer" id="cdk-adobe-eds.AdobeEDSConstructProps.Initializer"></a>
 
@@ -349,18 +349,18 @@ const eDSDistributionProps: EDSDistributionProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.edsURL">edsURL</a></code> | <code>string</code> | The URL for the Adobe EDS site deployment. |
+| <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.edsURL">edsURL</a></code> | <code>string</code> | The URL for the Adobe Edge Delivery Services site deployment. |
 | <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.prefix">prefix</a></code> | <code>string</code> | The environment prefix. |
 | <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.sendPushInvalidationHeader">sendPushInvalidationHeader</a></code> | <code>boolean</code> | Push invalidation can be enabled for CloudFront using a very aggressive wildcard, i.e. `/*`. If you've setup this up OR IF YOU PLAN TO SET THIS UP, setting this value to true will append the required headers as specified in the docs by Adobe. Note that this property will NOT automatically setup the invalidator IAM roles / policies, at this point that will need to be manual. Ideally this would be something handled using OpenID Connect if possible. |
 | <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.additionalBehaviors">additionalBehaviors</a></code> | <code>{[ key: string ]: aws-cdk-lib.aws_cloudfront.BehaviorOptions}</code> | If you'd like other behviors including in the CloudFront Distribution they can be added here. |
 | <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.certificate">certificate</a></code> | <code>aws-cdk-lib.aws_certificatemanager.ICertificate</code> | If you'd like to associate a certificate with this Distribution it can be provided here. |
-| <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.cloudFrontEDSFunction">cloudFrontEDSFunction</a></code> | <code>aws-cdk-lib.aws_cloudfront.Function</code> | If you prefer to supply your own EDS Origin CF Function you can, but beware that Adobe requires certain actions be performed by this function, e.g. removing the `age` header. If you override this Function you should be sure that it is handling any behavior required by EDS downstream. |
+| <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.cloudFrontEDSFunction">cloudFrontEDSFunction</a></code> | <code>aws-cdk-lib.aws_cloudfront.Function</code> | If you prefer to supply your own Edge Delivery Services Origin CF Function you can, but beware that Adobe requires certain actions be performed by this function, e.g. removing the `age` header. If you override this Function you should be sure that it is handling any behavior required by Edge Delivery Services downstream. |
 | <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.defaultBehaviorEdgeLambdas">defaultBehaviorEdgeLambdas</a></code> | <code>aws-cdk-lib.aws_cloudfront.EdgeLambda[]</code> | Any Lambda@Edge configurations you'd like to supply with the default origin. |
-| <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.domain">domain</a></code> | <code>string</code> | The domain (e.g. www.amazingwebsite.com) for the final website. This is past to EDS for handling URL mappings and such as the X-Forwarded-Host header. If not specified, this header is NOT sent. |
+| <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.domain">domain</a></code> | <code>string</code> | The domain (e.g. www.amazingwebsite.com) for the final website. This is past to Edge Delivery Services for handling URL mappings and such as the X-Forwarded-Host header. If not specified, this header is NOT sent. |
 | <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.domainNames">domainNames</a></code> | <code>string[]</code> | A list of domain names that should be associated with the Distribution. |
 | <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.enableLogging">enableLogging</a></code> | <code>boolean</code> | Enable logging for the distribution? If set to true a bucket will be created for logs. |
 | <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.enableOriginShield">enableOriginShield</a></code> | <code>boolean</code> | Origin Shield is recommended by Adobe but there are extra costs associated with it so is set to false by default to avoid unexpected costs. |
-| <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.originShieldRegion">originShieldRegion</a></code> | <code>string</code> | The region config for the default EDS region. |
+| <code><a href="#cdk-adobe-eds.EDSDistributionProps.property.originShieldRegion">originShieldRegion</a></code> | <code>string</code> | The region config for the default Edge Delivery Services region. |
 
 ---
 
@@ -372,7 +372,7 @@ public readonly edsURL: string;
 
 - *Type:* string
 
-The URL for the Adobe EDS site deployment.
+The URL for the Adobe Edge Delivery Services site deployment.
 
 This most likely will have a format similar to
 <main>--<project>--<github user>.hlx.live - note it is without the https:// and no trailing slash.
@@ -447,7 +447,7 @@ public readonly cloudFrontEDSFunction: Function;
 
 - *Type:* aws-cdk-lib.aws_cloudfront.Function
 
-If you prefer to supply your own EDS Origin CF Function you can, but beware that Adobe requires certain actions be performed by this function, e.g. removing the `age` header. If you override this Function you should be sure that it is handling any behavior required by EDS downstream.
+If you prefer to supply your own Edge Delivery Services Origin CF Function you can, but beware that Adobe requires certain actions be performed by this function, e.g. removing the `age` header. If you override this Function you should be sure that it is handling any behavior required by Edge Delivery Services downstream.
 
 ---
 
@@ -474,7 +474,7 @@ public readonly domain: string;
 
 - *Type:* string
 
-The domain (e.g. www.amazingwebsite.com) for the final website. This is past to EDS for handling URL mappings and such as the X-Forwarded-Host header. If not specified, this header is NOT sent.
+The domain (e.g. www.amazingwebsite.com) for the final website. This is past to Edge Delivery Services for handling URL mappings and such as the X-Forwarded-Host header. If not specified, this header is NOT sent.
 
 ---
 
@@ -530,7 +530,7 @@ public readonly originShieldRegion: string;
 
 - *Type:* string
 
-The region config for the default EDS region.
+The region config for the default Edge Delivery Services region.
 
 This propertly is only used if Origin Shield is enabled.
 Note no enum is provided here because there is no enum, so take care!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Adobe / AEM Edge Delivery Service (EDS) Construct
+# Adobe / AEM Edge Delivery Services Construct
 
 ## What is this?
 
-CDK Construct should provide a starting point for deploying a CDN in front of Edge Side Delivery (Franklin, Helix, AEM) with AWS CloudFront. After deploying the `AdobeEDS` Construct in your stack you should be able to access EDS through the Distribution's default CloudFront domain.
+CDK Construct should provide a starting point for deploying a CDN in front of Edge Delivery Services (Franklin, Helix, AEM) with AWS CloudFront. After deploying the `AdobeEDS` Construct in your stack you should be able to access Edge Delivery Services through the Distribution's default CloudFront domain.
 
 **[The configuration in this project is based on these recommendations in Adobe's BYO CDN documentation](https://www.aem.live/docs/byo-cdn-cloudfront-setup)**. _Note that via configuration you can match the Adobe recomendation configuration but the default configuration slightly deviates as noted below_.
 
@@ -17,12 +17,12 @@ npm install --save-dev cdk-adobe-eds
 
 ## Usage
 
-This basic example will result in a CloudFront Distribution being made with the default origin being backed by EDS.
+This basic example will result in a CloudFront Distribution being made with the default origin being backed by Edge Delivery Services.
 
 ```
 // my-adobe-eds-stack.ts
 
-// Create CDN for EDS on CloudFront
+// Create CDN for Edge Delivery Services on CloudFront
 new AdobeEDS(this, `sandbox-adobe-eds`, {
   // A friendly prefix for quickly glancing resources in your environment
   prefix: "sandbox",
@@ -30,9 +30,9 @@ new AdobeEDS(this, `sandbox-adobe-eds`, {
   invalidateAllOnDeploy: true,
   distributionConfig: {
     prefix: "sandbox",
-    // The EDS URL you'd like to use for the default origin
+    // The Edge Delivery Services URL you'd like to use for the default origin
     edsURL: "https://<branch>--<repo>--<account>.hlx.live",
-    // We won't send the push invalidation header to EDS.
+    // We won't send the push invalidation header to Edge Delivery Services.
     // Note this means we'll have to wait for the cache policy TTL to expire
     sendPushInvalidationHeader: false,
     // ...
@@ -48,17 +48,17 @@ There are a number of known deviations that can result in deployed infrastructur
 
 ### X-Forwarded-Host not set by default
 
-If you do not specify a domain in the `domain` property for the `EDSDistributionConstruct` the `X-Forwarded-Host` header is NOT sent. Note that in some testing it seems that EDS is smart enough to automatically swap out base domains for the CDN value even if this is not sent, but still this is a deviation. For those simply testing AWS with this set of Constructs (I suspect many may use this as a place to do some basic testing or may borrow from but not use as-is) the issue may be you want to test with the CloudFront domain, e.g. `dsomethingsomethingj.cloudfront.net` and in that case I'm not aware of a way to get the CloudFront domain name set on the default origin.
+If you do not specify a domain in the `domain` property for the `EDSDistributionConstruct` the `X-Forwarded-Host` header is NOT sent. Note that in some testing it seems that Edge Delivery Services is smart enough to automatically swap out base domains for the CDN value even if this is not sent, but still this is a deviation. For those simply testing AWS with this set of Constructs (I suspect many may use this as a place to do some basic testing or may borrow from but not use as-is) the issue may be you want to test with the CloudFront domain, e.g. `dsomethingsomethingj.cloudfront.net` and in that case I'm not aware of a way to get the CloudFront domain name set on the default origin.
 
 **[It may be possible to do this as the Distribution does expose `distributionDomainName`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.IDistribution.html#distributiondomainname)**, and I certainly welcome any improvements here. 
 
 ### Origin Shield not enabled by default
 
-Adobe specifies Origin Shield should be enabled. If you do not enable origin shield it would seem the CDN works well enough but in theory both performance and your relationship with Adobe may suffer as this could result in more requests to the EDS origin in a less optimial way. Because [Origin Shield adds additional cost beyond the free-tier (to the best of my understanding)](https://aws.amazon.com/cloudfront/pricing/) I prefer to disable it by default to avoid surprises to an individual who simply wants to experiement with AWS and Adobe EDS.
+Adobe specifies Origin Shield should be enabled. If you do not enable origin shield it would seem the CDN works well enough but in theory both performance and your relationship with Adobe may suffer as this could result in more requests to the Edge Delivery Services origin in a less optimial way. Because [Origin Shield adds additional cost beyond the free-tier (to the best of my understanding)](https://aws.amazon.com/cloudfront/pricing/) I prefer to disable it by default to avoid surprises to an individual who simply wants to experiement with AWS and Adobe Edge Delivery Services.
 
 ### TLS Version not pegged at TLSv1
 
-In the instructions under "[Configure the Origin](https://www.aem.live/docs/byo-cdn-cloudfront-setup#configure-the-origin)", although not highlighted as a mandatory setting the minimum TLS version selected by Adobe is TLSv1. The default is TLSv1.2 if not specified in CF and Fastly / Adobe EDS seems to handle this just fine. I would be surprised if this was an issue, but it's a black box to me so I wanted to call it out.
+In the instructions under "[Configure the Origin](https://www.aem.live/docs/byo-cdn-cloudfront-setup#configure-the-origin)", although not highlighted as a mandatory setting the minimum TLS version selected by Adobe is TLSv1. The default is TLSv1.2 if not specified in CF and Fastly / Adobe Edge Delivery Services seems to handle this just fine. I would be surprised if this was an issue, but it's a black box to me so I wanted to call it out.
 
 
 ## Note on Free Tier

--- a/src/adobe-eds.ts
+++ b/src/adobe-eds.ts
@@ -3,7 +3,7 @@ import { EDSDistributionProps, EDSDistribution } from './eds-distribution';
 import { EDSInvalidation } from './eds-invalidation';
 
 /**
- * All configuration options for the Adobe EDS CDN deployment.
+ * All configuration options for the Adobe Edge Delivery Services CDN deployment.
  */
 export interface AdobeEDSConstructProps {
   /**
@@ -25,7 +25,7 @@ export interface AdobeEDSConstructProps {
 }
 
 /**
- * Infrastructure for Adobe Edge Delivery Service.
+ * CDN infrastructure for Adobe Edge Delivery Services.
  */
 export class AdobeEDS extends Construct {
   edsDistribution: EDSDistribution;

--- a/src/eds-distribution.ts
+++ b/src/eds-distribution.ts
@@ -40,20 +40,20 @@ export interface EDSDistributionProps {
    */
   readonly prefix: string;
   /**
-   * The URL for the Adobe EDS site deployment. This most likely will have a format similar to
+   * The URL for the Adobe Edge Delivery Services site deployment. This most likely will have a format similar to
    * <main>--<project>--<github user>.hlx.live - note it is without the https:// and no trailing slash.
    * Also note that most likely this should be the `.live` version of the domain, not `.page` (preview).
    */
   readonly edsURL: string;
   /**
-   * The domain (e.g. www.amazingwebsite.com) for the final website. This is past to EDS for handling
+   * The domain (e.g. www.amazingwebsite.com) for the final website. This is past to Edge Delivery Services for handling
    * URL mappings and such as the X-Forwarded-Host header. If not specified, this header is NOT sent.
    */
   readonly domain?: string;
   /**
-   * If you prefer to supply your own EDS Origin CF Function you can, but beware that Adobe requires
+   * If you prefer to supply your own Edge Delivery Services Origin CF Function you can, but beware that Adobe requires
    * certain actions be performed by this function, e.g. removing the `age` header. If you override
-   * this Function you should be sure that it is handling any behavior required by EDS downstream.
+   * this Function you should be sure that it is handling any behavior required by Edge Delivery Services downstream.
    */
   readonly cloudFrontEDSFunction?: Function;
   /**
@@ -72,7 +72,7 @@ export interface EDSDistributionProps {
    */
   readonly enableOriginShield?: boolean;
   /**
-   * The region config for the default EDS region. This propertly is only used if Origin Shield is enabled.
+   * The region config for the default Edge Delivery Services region. This propertly is only used if Origin Shield is enabled.
    * Note no enum is provided here because there is no enum, so take care!
    * @see {@link https://github.com/aws/aws-sdk-java-v2/issues/3345}.
    */
@@ -107,7 +107,7 @@ export interface EDSDistributionProps {
 }
 
 /**
- * A high level Construct for creating infrastructure required to support Adobe AEM Edge Delivery Service. This stands for
+ * A high level Construct for creating infrastructure required to support Adobe AEM Edge Delivery Services. This stands for
  * "Edge Delivery Service Content Delivery Construct."
  * @see {@link https://www.aem.live/docs/byo-cdn-cloudfront-setup#configure-the-origin}
  */
@@ -116,9 +116,9 @@ export class EDSDistribution extends Construct {
 
   // Header for forwarding domain name downstream
   readonly xForwardedHostHeaderName = 'X-Forwarded-Host';
-  // Adobe EDS specific header for letting EDS know which cloud provider is acting as the CDN
+  // Adobe Edge Delivery Services specific header for letting know which cloud provider is acting as the CDN
   readonly xBYOHeaderName = 'X-BYO-CDN-Type';
-  // The Adobe EDS value expected for AWS CloudFront
+  // The Adobe Edge Delivery Services value expected for AWS CloudFront
   readonly xBYOHeaderValue = 'cloudfront';
 
   constructor(scope: Construct, id: string, props: EDSDistributionProps) {
@@ -163,7 +163,10 @@ export class EDSDistribution extends Construct {
             ...originShieldOriginOptions,
             protocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,
             // Note that the Adobe doc screenshots actually show TLS_V1, but don't specify it as required
-            originSslProtocols: [OriginSslPolicy.TLS_V1_1, OriginSslPolicy.TLS_V1_2],
+            originSslProtocols: [
+              OriginSslPolicy.TLS_V1_1,
+              OriginSslPolicy.TLS_V1_2,
+            ],
             customHeaders: {
               ...domainHeader,
               [this.xBYOHeaderName]: this.xBYOHeaderValue,
@@ -196,7 +199,7 @@ export class EDSDistribution extends Construct {
   }
 
   /**
-   * Creates a new {@link CachePolicy} matching the details provided by the Adobe EDS documentation.
+   * Creates a new {@link CachePolicy} matching the details provided by the Adobe Edge Delivery Services documentation.
    *
    * @param props cache policy configuration flags and options
    * @returns a {@link CachePolicy}
@@ -212,7 +215,8 @@ export class EDSDistribution extends Construct {
       cookieBehavior: CacheCookieBehavior.none(),
       enableAcceptEncodingGzip: true,
       enableAcceptEncodingBrotli: true,
-      comment: 'Adobe EDS CachePolicy for Edge Delivery Service',
+      comment:
+        'Adobe Edge Delivery Services CachePolicy for Edge Delivery Service',
     });
   }
 
@@ -249,7 +253,7 @@ export class EDSDistribution extends Construct {
   private createDefaultOriginFunction(props: { prefix: string }): IFunction {
     return new Function(this, `${props.prefix}-eds-default-origin-function`, {
       functionName: `${props.prefix}-eds-default-origin-function`,
-      comment: 'EDS CDN CF Function for removing age header',
+      comment: 'Edge Delivery Services CDN CF Function for removing age header',
       code: FunctionCode.fromInline(`
         function handler(event) {
           // remove Age header


### PR DESCRIPTION
* Use long form `EDS` => `Edge Delivery Service`
* `Edge Side Delivery` was a typo, fixed to Edge Delivery Services

Fixes #